### PR TITLE
Fix PHP deprecation warnings in WebPrintApi

### DIFF
--- a/src/Response/Printer.php
+++ b/src/Response/Printer.php
@@ -14,7 +14,7 @@ class Printer
     private ?array $ppd_options;
     private ?array $ppd_options_layout;
 
-    public function __construct(string $ulid, string $name, bool $ppd_support, array $raw_languages_supported, ?Server $server = null, array $ppd_options = null, array $ppd_options_layout = null)
+    public function __construct(string $ulid, string $name, bool $ppd_support, array $raw_languages_supported, ?Server $server = null, ?array $ppd_options = null, ?array $ppd_options_layout = null)
     {
         $this->ulid = $ulid;
         $this->server = $server;

--- a/src/WebPrintApi.php
+++ b/src/WebPrintApi.php
@@ -17,7 +17,7 @@ class WebPrintApi implements WebPrintApiInterface
         $this->client = $client;
     }
 
-    public function GetPrinters(string $type_filter = null, bool $with_ppd_options = false): array
+    public function GetPrinters(?string $type_filter = null, bool $with_ppd_options = false): array
     {
         $query = [];
 
@@ -42,7 +42,7 @@ class WebPrintApi implements WebPrintApiInterface
         return Printer::fromResponse($response);
     }
 
-    public function GetPromises(int $page = 1, int &$total_pages = null): array
+    public function GetPromises(int $page = 1, ?int &$total_pages = null): array
     {
         $response = $this->client->get('promises', ['page' => $page]);
         $body = json_decode($response, true);
@@ -136,7 +136,7 @@ class WebPrintApi implements WebPrintApiInterface
     }
 
 
-    public function CreateDialog(string $ulid, bool $auto_print = true, string $redirect_url = null, string $restricted_ip = null): Dialog
+    public function CreateDialog(string $ulid, bool $auto_print = true, ?string $redirect_url = null, ?string $restricted_ip = null): Dialog
     {
         $response = $this->client->post(sprintf("promises/%s/dialog", urlencode($ulid)), [
             'restricted_ip' => $restricted_ip,

--- a/src/WebPrintApiInterface.php
+++ b/src/WebPrintApiInterface.php
@@ -15,7 +15,7 @@ interface WebPrintApiInterface
      *
      * @return array|Printer[]
      */
-    public function GetPrinters(string $type_filter = null, bool $with_ppd_options = false): array;
+    public function GetPrinters(?string $type_filter = null, bool $with_ppd_options = false): array;
 
     public function GetPrinter(string $ulid): Printer;
 
@@ -25,7 +25,7 @@ interface WebPrintApiInterface
      *
      * @return array|Promise[]
      */
-    public function GetPromises(int $page = 1, int &$total_pages = null): array;
+    public function GetPromises(int $page = 1, ?int &$total_pages = null): array;
 
     public function GetPromise(string $ulid): Promise;
 
@@ -39,7 +39,7 @@ interface WebPrintApiInterface
 
     public function CreatePromiseAndPrint(string $name, string $type, string $printer_ulid, string $file_name, string $content, ?array $ppd_options = null): Promise;
 
-    public function CreateDialog(string $ulid, bool $auto_print, string $redirect_url, string $restricted_ip = null): Dialog;
+    public function CreateDialog(string $ulid, bool $auto_print, ?string $redirect_url, ?string $restricted_ip = null): Dialog;
 
     public function GetDialog(string $ulid): Dialog;
 


### PR DESCRIPTION
Added explicit nullable type hints (?) to parameters with null default values:
- WebPrintApi::GetPrinters() - $type_filter parameter
- WebPrintApi::GetPromises() - $total_pages parameter
- WebPrintApi::CreateDialog() - $redirect_url and $restricted_ip parameters
- WebPrintApiInterface methods - matching interface signatures
- Printer::__construct() - $ppd_options and $ppd_options_layout parameters

This resolves the "Implicitly marking parameter as nullable is deprecated" warnings that appear in PHP 8.1 and later versions.